### PR TITLE
Secretariat can change compiler of questionnaire

### DIFF
--- a/apps/accounts/fixtures/groups_permissions.json
+++ b/apps/accounts/fixtures/groups_permissions.json
@@ -370,6 +370,11 @@
           "questionnaire"
         ],
         [
+          "change_compiler",
+          "questionnaire",
+          "questionnaire"
+        ],
+        [
           "add_project",
           "configuration",
           "project"

--- a/apps/questionnaire/migrations/0017_auto_20170313_1724.py
+++ b/apps/questionnaire/migrations/0017_auto_20170313_1724.py
@@ -1,0 +1,23 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('questionnaire', '0016_auto_20170124_1119'),
+    ]
+
+    operations = [
+        migrations.AlterModelOptions(
+            name='questionnaire',
+            options={'ordering': ['-updated'], 'permissions': (('review_questionnaire', 'Can review questionnaire'), ('publish_questionnaire', 'Can publish questionnaire'), ('assign_questionnaire', 'Can assign questionnaire (for review/publish)'), ('view_questionnaire', 'Can view questionnaire'), ('edit_questionnaire', 'Can edit questionnaire'), ('change_compiler', 'Can change compiler of questionnaire'), ('flag_unccd_questionnaire', 'Can flag UNCCD questionnaire'), ('unflag_unccd_questionnaire', 'Can unflag UNCCD questionnaire'))},
+        ),
+        migrations.AlterField(
+            model_name='questionnairetranslation',
+            name='language',
+            field=models.CharField(max_length=63, choices=[('en', 'English'), ('fr', 'French'), ('es', 'Spanish'), ('ru', 'Russian'), ('km', 'Khmer'), ('lo', 'Lao'), ('ar', 'Arabic'), ('bs', 'Bosnian'), ('pt', 'Portuguese')]),
+        ),
+    ]

--- a/apps/questionnaire/models.py
+++ b/apps/questionnaire/models.py
@@ -114,6 +114,7 @@ class Questionnaire(models.Model):
              "Can assign questionnaire (for review/publish)"),
             ("view_questionnaire", "Can view questionnaire"),
             ("edit_questionnaire", "Can edit questionnaire"),
+            ("change_compiler", "Can change compiler of questionnaire"),
             ("flag_unccd_questionnaire", "Can flag UNCCD questionnaire"),
             ("unflag_unccd_questionnaire", "Can unflag UNCCD questionnaire"),
         )
@@ -477,7 +478,7 @@ class Questionnaire(models.Model):
             permissions.extend(
                 ['edit_questionnaire', 'delete_questionnaire',
                  'submit_questionnaire', 'review_questionnaire',
-                 'publish_questionnaire'])
+                 'publish_questionnaire', 'change_compiler'])
             if self.status in [settings.QUESTIONNAIRE_SUBMITTED,
                                settings.QUESTIONNAIRE_REVIEWED]:
                 permissions.extend(['assign_questionnaire'])

--- a/apps/questionnaire/templates/details/category/approaches_header.html
+++ b/apps/questionnaire/templates/details/category/approaches_header.html
@@ -40,7 +40,7 @@
       <li>
         <span class="is-muted">{% if metadata.editors|length > 1 %}{% trans "Editors:" %}{% else %}{% trans "Editor:" %}{% endif %}</span>
         {% for editor in metadata.editors %}
-          <a rel="author" href="#" class="link">{{ editor.name }}</a>{% if not forloop.last %}, {% endif %}
+          <a rel="author" href="{% url 'user_details' editor.id %}" class="link">{{ editor.name }}</a>{% if not forloop.last %}, {% endif %}
         {% empty %}
           &ndash;
         {% endfor %}

--- a/apps/questionnaire/templates/details/category/cca_header.html
+++ b/apps/questionnaire/templates/details/category/cca_header.html
@@ -37,7 +37,7 @@
       <li>
         <span class="is-muted">{% if metadata.editors|length > 1 %}{% trans "Editors:" %}{% else %}{% trans "Editor:" %}{% endif %}</span>
         {% for editor in metadata.editors %}
-          <a rel="author" href="#" class="link">{{ editor.name }}</a>{% if not forloop.last %}, {% endif %}
+          <a rel="author" href="{% url 'user_details' editor.id %}" class="link">{{ editor.name }}</a>{% if not forloop.last %}, {% endif %}
         {% empty %}
           &ndash;
         {% endfor %}

--- a/apps/questionnaire/templates/details/category/samplemodule_header.html
+++ b/apps/questionnaire/templates/details/category/samplemodule_header.html
@@ -36,7 +36,7 @@
       <li>
         <span class="is-muted">{% if metadata.editors|length > 1 %}{% trans "Editors:" %}{% else %}{% trans "Editor:" %}{% endif %}</span>
         {% for editor in metadata.editors %}
-          <a rel="author" href="#" class="link">{{ editor.name }}</a>{% if not forloop.last %}, {% endif %}
+          <a rel="author" href="{% url 'user_details' editor.id %}" class="link">{{ editor.name }}</a>{% if not forloop.last %}, {% endif %}
         {% empty %}
           &ndash;
         {% endfor %}

--- a/apps/questionnaire/templates/details/category/technologies_header.html
+++ b/apps/questionnaire/templates/details/category/technologies_header.html
@@ -40,7 +40,7 @@
       <li>
         <span class="is-muted">{% if metadata.editors|length > 1 %}{% trans "Editors:" %}{% else %}{% trans "Editor:" %}{% endif %}</span>
         {% for editor in metadata.editors %}
-          <a rel="author" href="#" class="link">{{ editor.name }}</a>{% if not forloop.last %}, {% endif %}
+          <a rel="author" href="{% url 'user_details' editor.id %}" class="link">{{ editor.name }}</a>{% if not forloop.last %}, {% endif %}
         {% empty %}
           &ndash;
         {% endfor %}

--- a/apps/questionnaire/templates/details/category/unccd_header.html
+++ b/apps/questionnaire/templates/details/category/unccd_header.html
@@ -37,7 +37,7 @@
       <li>
         <span class="is-muted">{% if metadata.editors|length > 1 %}{% trans "Editors:" %}{% else %}{% trans "Editor:" %}{% endif %}</span>
         {% for editor in metadata.editors %}
-          <a rel="author" href="#" class="link">{{ editor.name }}</a>{% if not forloop.last %}, {% endif %}
+          <a rel="author" href="{% url 'user_details' editor.id %}" class="link">{{ editor.name }}</a>{% if not forloop.last %}, {% endif %}
         {% empty %}
           &ndash;
         {% endfor %}

--- a/apps/questionnaire/templates/details/category/watershed_header.html
+++ b/apps/questionnaire/templates/details/category/watershed_header.html
@@ -40,7 +40,7 @@
       <li>
         <span class="is-muted">{% if metadata.editors|length > 1 %}{% trans "Editors:" %}{% else %}{% trans "Editor:" %}{% endif %}</span>
         {% for editor in metadata.editors %}
-          <a rel="author" href="#" class="link">{{ editor.name }}</a>{% if not forloop.last %}, {% endif %}
+          <a rel="author" href="{% url 'user_details' editor.id %}" class="link">{{ editor.name }}</a>{% if not forloop.last %}, {% endif %}
         {% empty %}
           &ndash;
         {% endfor %}

--- a/apps/questionnaire/templates/details/category/with_metadata.html
+++ b/apps/questionnaire/templates/details/category/with_metadata.html
@@ -36,7 +36,7 @@
       <li>
         <span class="is-muted">{% if metadata.editors|length > 1 %}{% trans "Editors:" %}{% else %}{% trans "Editor:" %}{% endif %}</span>
         {% for editor in metadata.editors %}
-          <a rel="author" href="#" class="link">{{ editor.name }}</a>{% if not forloop.last %}, {% endif %}
+          <a rel="author" href="{% url 'user_details' editor.id %}" class="link">{{ editor.name }}</a>{% if not forloop.last %}, {% endif %}
         {% empty %}
           &ndash;
         {% endfor %}

--- a/apps/questionnaire/templates/details/review_panel/_assign_user.html
+++ b/apps/questionnaire/templates/details/review_panel/_assign_user.html
@@ -40,7 +40,7 @@
       {% if not users %}<i class="is-muted">{{ assign_empty }}</i>{% endif %}
     </div>
   <div class="row">
-    <div class="medium-12 columns hide" id="review-edit-assigned-users">
+    <div class="medium-12 columns hide review-assigned-users" id="review-edit-assigned-users">
       <a href="#" class="review-assigned-users-toggle js-toggle-edit-assigned-users">
         <svg class="icon"><use xlink:href="#icon-cross" xmlns:xlink="http://www.w3.org/1999/xlink"></use></svg>
       </a>
@@ -63,6 +63,7 @@
                  placeholder="{% trans 'Search user' %}"
                  data-search-url="{% url 'user_search' %}"
                  data-display-container="review-new-user"
+                 data-user-input-field="user-id"
                  data-translation-no-results="{% trans 'No results found' %}"
                  data-translation-too-many-results="{% trans 'Too many results found, please narrow the search' %}">
         </div>

--- a/apps/questionnaire/templates/details/review_panel/_change_compiler.html
+++ b/apps/questionnaire/templates/details/review_panel/_change_compiler.html
@@ -1,0 +1,37 @@
+<div class="row process-action">
+  <div class="medium-2 columns">
+    <a class="button expand" data-toggle="review-change-compiler-panel">Change compiler</a>
+  </div>
+  <div class="medium-10 columns">
+    <p>As a member of the WOCAT secretariat, you can change the compiler of this {{ questionnaire_type }}.</p>
+
+    <div class="row">
+      <div class="medium-12 columns hide review-assigned-users" id="review-change-compiler-panel">
+        <a href="#" class="review-assigned-users-toggle" data-toggle="review-change-compiler-panel">
+          <svg class="icon"><use xlink:href="#icon-cross" xmlns:xlink="http://www.w3.org/1999/xlink"></use></svg>
+        </a>
+        <p>Search and select a user who will be the new compiler of this {{ questionnaire_type }}.</p>
+        <div class="row">
+          <div class="medium-9 columns">
+            <div id="review-new-compiler" class="user-display">
+              <input type="hidden" name="compiler-id" value="">
+            </div>
+            <input type="search"
+                   id="review-change-compiler"
+                   placeholder="Search user"
+                   data-search-url="{% url 'user_search' %}"
+                   data-user-input-field="compiler-id"
+                   data-max-users="1"
+                   data-translation-no-results="No results found"
+                   data-translation-too-many-results="Too many results found, please narrow the search"
+                   data-display-container="review-new-compiler">
+          </div>
+          <div class="medium-2 medium-offset-1 columns">
+            <label><input type="checkbox" name="change-compiler-keep-editor"> Keep the current compiler as editor?</label>
+            <input type="submit" id="button-change-compiler" name="change-compiler" class="button expand" value="Change compiler">
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/apps/questionnaire/templates/details/review_panel/_change_compiler.html
+++ b/apps/questionnaire/templates/details/review_panel/_change_compiler.html
@@ -28,7 +28,7 @@
           </div>
           <div class="medium-2 medium-offset-1 columns">
             <label><input type="checkbox" name="change-compiler-keep-editor"> Keep the current compiler as editor?</label>
-            <input type="submit" id="button-change-compiler" name="change-compiler" class="button expand" value="Change compiler">
+            <input type="submit" id="button-change-compiler" name="change-compiler" class="button expand" value="Update compiler">
           </div>
         </div>
       </div>

--- a/apps/questionnaire/templates/details/review_panel/draft.html
+++ b/apps/questionnaire/templates/details/review_panel/draft.html
@@ -111,3 +111,7 @@
   {% trans "Please note that currently, invited users are not notified automatically. This feature is in development and will be added soon. For the time being, it is recommended to notify invited users via e-mail." as assign_notice %}
   {% include 'details/review_panel/_assign_user.html' with users=review_config.editors questionnaire_type=questionnaire_type review_status=review_config.review_status %}
 {% endif %}
+
+{% if 'change_compiler' in review_config.permissions %}
+  {% include 'details/review_panel/_change_compiler.html' %}
+{% endif %}

--- a/apps/questionnaire/templates/details/review_panel/edit.html
+++ b/apps/questionnaire/templates/details/review_panel/edit.html
@@ -42,6 +42,10 @@
   {% include 'details/review_panel/_delete.html' %}
 {% endif %}
 
+{% if 'change_compiler' in review_config.permissions %}
+  {% include 'details/review_panel/_change_compiler.html' %}
+{% endif %}
+
 {% if 'flag_unccd_questionnaire' in review_config.permissions %}
   <div class="row process-action">
     <div class="medium-2 columns">

--- a/apps/questionnaire/templates/details/review_panel/publish.html
+++ b/apps/questionnaire/templates/details/review_panel/publish.html
@@ -120,3 +120,7 @@
   {% trans "Please note that currently, invited users are not notified automatically. This feature is in development and will be added soon. For the time being, it is recommended to notify invited users via e-mail." as assign_notice %}
   {% include 'details/review_panel/_assign_user.html' with users=review_config.publishers  questionnaire_type=questionnaire_type review_status=review_config.review_status %}
 {% endif %}
+
+{% if 'change_compiler' in review_config.permissions %}
+  {% include 'details/review_panel/_change_compiler.html' %}
+{% endif %}

--- a/apps/questionnaire/templates/details/review_panel/review.html
+++ b/apps/questionnaire/templates/details/review_panel/review.html
@@ -117,3 +117,7 @@
   {% trans "Please note that currently, invited users are not notified automatically. This feature is in development and will be added soon. For the time being, it is recommended to notify invited users via e-mail." as assign_notice %}
   {% include 'details/review_panel/_assign_user.html' with users=review_config.reviewers questionnaire_type=questionnaire_type review_status=review_config.review_status %}
 {% endif %}
+
+{% if 'change_compiler' in review_config.permissions %}
+  {% include 'details/review_panel/_change_compiler.html' %}
+{% endif %}

--- a/apps/questionnaire/templates/questionnaire/details.html
+++ b/apps/questionnaire/templates/questionnaire/details.html
@@ -9,7 +9,7 @@
 
 {% block content %}
 
-  {% if 'assign_questionnaire' in permissions %}
+  {% if 'assign_questionnaire' in permissions or 'change_compiler' in permissions %}
     {% addtoblock 'js' %}
       <script src="{% static 'js/jquery-ui.min.js' %}"></script>
       <script src="{% static 'js/review.min.js' %}"></script>

--- a/apps/questionnaire/tests/test_models.py
+++ b/apps/questionnaire/tests/test_models.py
@@ -395,7 +395,8 @@ class QuestionnaireModelTest(TestCase):
         self.assertEqual(roles, [('secretariat', 'WOCAT Secretariat')])
         expected_permissions = ['assign_questionnaire', 'review_questionnaire',
                                 'delete_questionnaire', 'submit_questionnaire',
-                                'edit_questionnaire', 'publish_questionnaire']
+                                'edit_questionnaire', 'publish_questionnaire',
+                                'change_compiler']
         self.assertTrue(
             len(permissions) == len(expected_permissions) and sorted(
                 permissions) == sorted(expected_permissions))
@@ -741,7 +742,7 @@ class QuestionnaireModelTest(TestCase):
         self.assertEqual(len(links_property), 1)
 
     def test_get_name(self):
-        self.assertDictEqual(
+        self.assertEqual(
             self.get_questionnaire_with_name().get_name(),
             'bread'
         )

--- a/apps/questionnaire/tests/test_utils.py
+++ b/apps/questionnaire/tests/test_utils.py
@@ -5,7 +5,9 @@ from unittest.mock import patch, Mock, call, MagicMock
 from collections import namedtuple
 
 from django.conf import settings
+from django.contrib.auth.models import Group
 from django.http import QueryDict
+from django.test.client import RequestFactory
 from django.test.utils import override_settings
 from django.utils.translation import ugettext_lazy as _
 from model_mommy import mommy
@@ -1320,6 +1322,151 @@ class HandleReviewActionsTest(TestCase):
         self.obj.get_users_by_role.return_value = [mock_user]
         handle_review_actions(self.request, self.obj, 'sample')
         self.obj.remove_user.assert_called_once_with(mock_user, 'reviewer')
+
+    def test_change_compiler_requires_permissions(self, mock_messages):
+        self.obj.status = 2
+        self.request.POST = {'change-compiler': 'foo'}
+        handle_review_actions(self.request, self.obj, 'sample')
+        mock_messages.error.assert_called_once_with(
+            self.request,
+            'You do not have permissions to change the compiler!')
+
+    @patch('questionnaire.signals.change_member.send')
+    def test_change_compiler_handles_non_valid_ids(
+            self, mock_change_member, mock_messages):
+        self.obj.status = 2
+        self.request.POST = {
+            'change-compiler': 'foo',
+            'compiler-id': 'foo',
+        }
+        RolesPermissions = namedtuple(
+            'RolesPermissions', ['roles', 'permissions'])
+        self.obj.get_roles_permissions.return_value = RolesPermissions(
+            roles=[], permissions=['change_compiler'])
+        handle_review_actions(self.request, self.obj, 'sample')
+        mock_messages.error.assert_called_once_with(
+            self.request,
+            'No valid new compiler provided!')
+
+    def test_change_compiler_handles_empty_id(self, mock_messages):
+        self.obj.status = 2
+        self.request.POST = {
+            'change-compiler': 'foo',
+            'compiler-id': '',
+        }
+        RolesPermissions = namedtuple(
+            'RolesPermissions', ['roles', 'permissions'])
+        self.obj.get_roles_permissions.return_value = RolesPermissions(
+            roles=[], permissions=['change_compiler'])
+        handle_review_actions(self.request, self.obj, 'sample')
+        mock_messages.error.assert_called_once_with(
+            self.request,
+            'No valid new compiler provided!')
+
+    def test_change_compiler_allows_only_one_id(self, mock_messages):
+        self.obj.status = 2
+        self.request.POST = {
+            'change-compiler': 'foo',
+            'compiler-id': '1,2,3',
+        }
+        RolesPermissions = namedtuple(
+            'RolesPermissions', ['roles', 'permissions'])
+        self.obj.get_roles_permissions.return_value = RolesPermissions(
+            roles=[], permissions=['change_compiler'])
+        handle_review_actions(self.request, self.obj, 'sample')
+        mock_messages.error.assert_called_once_with(
+            self.request,
+            'You can only choose one new compiler!')
+
+    def test_change_compiler_do_nothing_if_no_new_compiler(self, mock_messages):
+        self.obj.status = 2
+        self.request.POST = {
+            'change-compiler': 'foo',
+            'compiler-id': '1',
+        }
+        user = create_new_user(id=1)
+        RolesPermissions = namedtuple(
+            'RolesPermissions', ['roles', 'permissions'])
+        self.obj.get_roles_permissions.return_value = RolesPermissions(
+            roles=[], permissions=['change_compiler'])
+        self.obj.get_users_by_role.return_value = [user]
+        handle_review_actions(self.request, self.obj, 'sample')
+        mock_messages.info.assert_called_once_with(
+            self.request,
+            'This user is already the compiler.')
+
+
+@patch('questionnaire.utils.messages')
+class HandleReviewActionsTestFixtures(TestCase):
+
+    fixtures = ['groups_permissions', 'global_key_values', 'sample']
+
+    def setUp(self):
+        self.factory = RequestFactory()
+        self.request = self.factory.get('/')
+        self.request.user = create_new_user(lastname='1')
+        self.request.user.groups = [Group.objects.get(pk=5)]
+
+    @patch('questionnaire.utils.typo3_client')
+    @patch('questionnaire.signals.change_member.send')
+    def test_change_compiler(
+            self, mock_change_member, mock_typo3_client, mock_messages):
+
+        old_compiler = create_new_user(id=2, email='2@foo.com', lastname='2')
+        questionnaire = get_valid_questionnaire(old_compiler)
+
+        new_compiler = create_new_user(id=3, email='3@foo.com', lastname='3')
+
+        self.request.POST = {
+            'change-compiler': 'foo',
+            'compiler-id': '3',
+        }
+        mock_typo3_client.get_user_information.return_value = {
+            'username': 'user'
+        }
+        self.assertEqual(
+            questionnaire.get_users_by_role(settings.QUESTIONNAIRE_COMPILER),
+            [old_compiler])
+        handle_review_actions(self.request, questionnaire, 'sample')
+        self.assertEqual(
+            questionnaire.get_users_by_role(settings.QUESTIONNAIRE_COMPILER),
+            [new_compiler])
+        mock_messages.success.assert_called_once_with(
+            self.request,
+            'Compiler was changed successfully')
+
+    @patch('questionnaire.utils.typo3_client')
+    @patch('questionnaire.signals.change_member.send')
+    def test_keep_compiler_as_editor(
+            self, mock_change_member, mock_typo3_client, mock_messages):
+        old_compiler = create_new_user(id=2, email='2@foo.com', lastname='2')
+        questionnaire = get_valid_questionnaire(old_compiler)
+
+        new_compiler = create_new_user(id=3, email='3@foo.com', lastname='3')
+
+        self.request.POST = {
+            'change-compiler': 'foo',
+            'compiler-id': '3',
+            'change-compiler-keep-editor': 'foo',
+        }
+        mock_typo3_client.get_user_information.return_value = {
+            'username': 'user'
+        }
+        self.assertEqual(
+            questionnaire.get_users_by_role(settings.QUESTIONNAIRE_COMPILER),
+            [old_compiler])
+        self.assertEqual(
+            questionnaire.get_users_by_role(settings.QUESTIONNAIRE_EDITOR), [])
+        handle_review_actions(self.request, questionnaire, 'sample')
+        self.assertEqual(
+            questionnaire.get_users_by_role(settings.QUESTIONNAIRE_COMPILER),
+            [new_compiler])
+        self.assertEqual(
+            questionnaire.get_users_by_role(settings.QUESTIONNAIRE_EDITOR),
+            [old_compiler])
+        mock_messages.success.assert_called_once_with(
+            self.request,
+            'Compiler was changed successfully')
 
 
 @patch('questionnaire.utils.messages')

--- a/apps/questionnaire/utils.py
+++ b/apps/questionnaire/utils.py
@@ -1431,6 +1431,94 @@ def handle_review_actions(request, questionnaire_object, configuration_code):
             messages.error(request, 'At least one of the assigned users could '
                                     'not be updated.')
 
+    elif request.POST.get('change-compiler'):
+
+        if 'change_compiler' not in permissions:
+            messages.error(
+                request, 'You do not have permissions to change the compiler!')
+            return
+
+        # Check the submitted user IDs
+        user_ids_string = request.POST.get('compiler-id', '').split(',')
+
+        if len(user_ids_string) > 1:
+            messages.error(request, 'You can only choose one new compiler!')
+            return
+
+        try:
+            user_id = int(user_ids_string[0])
+        except ValueError:
+            messages.error(request, 'No valid new compiler provided!')
+            return
+
+        # Create or update the user
+        user_info = typo3_client.get_user_information(user_id)
+        if not user_info:
+            messages.error(
+                request,
+                'No user information found for user {}'.format(user_id))
+        new_compiler, created = User.objects.get_or_create(pk=user_id)
+        typo3_client.update_user(new_compiler, user_info)
+
+        role_compiler = settings.QUESTIONNAIRE_COMPILER
+
+        # Get old compiler(s) -> there should always only be 1
+        previous_compilers = questionnaire_object.get_users_by_role(
+            role_compiler)
+
+        # Do not do anything if the new compiler is already the old compiler.
+        if previous_compilers == [new_compiler]:
+            messages.info(request, 'This user is already the compiler.')
+            return
+
+        # Remove old compiler
+        for pc in previous_compilers:
+            change_member.send(
+                sender=settings.NOTIFICATIONS_REMOVE_MEMBER,
+                questionnaire=questionnaire_object,
+                user=request.user,
+                affected=pc,
+                role=role_compiler
+            )
+            questionnaire_object.remove_user(pc, role_compiler)
+
+        # Add new compiler
+        questionnaire_object.add_user(new_compiler, role_compiler)
+        change_member.send(
+            sender=settings.NOTIFICATIONS_ADD_MEMBER,
+            questionnaire=questionnaire_object,
+            user=request.user,
+            affected=new_compiler,
+            role=role_compiler
+        )
+
+        keep_as_editor = request.POST.get('change-compiler-keep-editor')
+        if keep_as_editor is not None:
+            # Keep the previous compiler as editor
+            role_editor = settings.QUESTIONNAIRE_EDITOR
+            editors = questionnaire_object.get_users_by_role(role_editor)
+            for pc in previous_compilers:
+                # Do not add again if already an editor
+                if pc in editors:
+                    continue
+                questionnaire_object.add_user(pc, role_editor)
+                change_member.send(
+                    sender=settings.NOTIFICATIONS_ADD_MEMBER,
+                    questionnaire=questionnaire_object,
+                    user=request.user,
+                    affected=pc,
+                    role=role_editor
+                )
+
+        # Re-add the questionnaire to ES if it was public
+        if questionnaire_object.status == settings.QUESTIONNAIRE_PUBLIC:
+            delete_questionnaires_from_es(
+                configuration_code, [questionnaire_object])
+            added, errors = put_questionnaire_data(
+                configuration_code, [questionnaire_object])
+
+        messages.success(request, 'Compiler was changed successfully')
+
     elif request.POST.get('flag-unccd'):
 
         if 'flag_unccd_questionnaire' not in permissions:

--- a/functional_tests/sample/test_edit.py
+++ b/functional_tests/sample/test_edit.py
@@ -1156,10 +1156,7 @@ class LockTest(FunctionalTest):
         )
         # and the edit button has no url, but a message about the locked status
         edit_button = self.findBy('link_text', 'Edit')
-        self.assertTrue(
-            edit_button.get_attribute('disabled')
-
-        )
+        self.assertTrue(edit_button.get_attribute('disabled'))
         self.findBy('xpath', '//*[text()[contains(.,"This questionnaire is '
                              'locked for editing by jay None.")]]')
 

--- a/src/js/review.js
+++ b/src/js/review.js
@@ -66,17 +66,27 @@
             }
 
             var displayContainer = $('#' + $(this).data('display-container'));
+            var userInputFieldName = $(this).data('user-input-field');
+            var maxUsers = $(this).data('max-users');
+            var currentUserCount = getCurrentUserCount(displayContainer);
 
-            addUserId(displayContainer, ui.item.uid);
-            displayUser(displayContainer, ui.item.uid, ui.item.first_name,
-                ui.item.last_name);
-
+            if (maxUsers === undefined || currentUserCount < maxUsers) {
+                addUserId(displayContainer, ui.item.uid, userInputFieldName);
+                displayUser(displayContainer, ui.item.uid, ui.item.first_name,
+                    ui.item.last_name);
+            }
+            
+            if (maxUsers && currentUserCount + 1 >= maxUsers) {
+                $(this).prop('disabled', true);
+            }
+        
             $(this).val('');
             return false;
         }
     };
 
     $('#review-search-user').autocomplete(autocompleteOptions);
+    $('#review-change-compiler').autocomplete(autocompleteOptions);
 
     function displayUser(container, userId, userFirstName, userLastName) {
         container.append($('<div>').addClass('alert-box').html(userFirstName + ' ' + userLastName + '<a href="#" ' +
@@ -84,8 +94,8 @@
         '&times;</a>'));
     }
 
-    function addUserId(container, userId) {
-        var input = container.find('[name="user-id"]');
+    function addUserId(container, userId, userInputFieldName) {
+        var input = container.find('[name="' + userInputFieldName + '"]');
         var ids = input.val().split(',').filter(function(n) { return n != "" });
         ids.push(userId);
         input.val(ids.join(','));
@@ -100,9 +110,13 @@
 
 })(jQuery);
 
+function getCurrentUserCount(container) {
+    return container.find('div.alert-box').length;
+}
+
 function reviewRemoveUser(el, userId) {
     var displayField = $(el).closest('.alert-box');
-    var input = displayField.siblings('[name="user-id"]');
+    var input = displayField.siblings('input:hidden');
 
     if (!input.length) {
         return false;
@@ -111,7 +125,16 @@ function reviewRemoveUser(el, userId) {
         return n != "" && n != String(userId) });
     input.val(ids.join(','));
 
+    var displayContainer = displayField.parent('.user-display');
+    var searchField = displayContainer.siblings('input');
+    var maxUsers = searchField.data('max-users');
+    var currentUserCount = getCurrentUserCount(displayContainer);
+
     displayField.remove();
+    
+    if (maxUsers !== undefined && currentUserCount < maxUsers) {
+        searchField.prop('disabled', false);
+    }
 
     return false;
 }

--- a/src/scss/module/_process.scss
+++ b/src/scss/module/_process.scss
@@ -64,7 +64,7 @@
   margin-top: 1rem;
 }
 
-#review-edit-assigned-users {
+.review-assigned-users {
 
   margin-top: 1rem;
 
@@ -109,7 +109,7 @@
     }
   }
 
-  #button-assign {
+  #button-assign, #button-change-compiler {
     margin-top: rem-calc(6);
   }
 }


### PR DESCRIPTION
* Only members of WOCAT secretariat can change compiler
* Reuse user search from assign user (as editor, revier etc.)
* Also link user details for editor in questionnaire details view

On purpose no translations as this feature is only available to members of WOCAT secretariat.