### PR TITLE
 - Handle error in tests from addition of compiler field in API

### DIFF
--- a/apps/questionnaire/api/views.py
+++ b/apps/questionnaire/api/views.py
@@ -103,8 +103,8 @@ class QuestionnaireAPIMixin(PermissionMixin, LogUserMixin, GenericAPIView):
                 'name': item.get('name'),
                 'created': item.get('created'),
                 'updated': item.get('updated'),
-                'compiler': item.get('compilers')[0]['name'],
-                'reviewer': [reviewers['name'] for reviewers in item.get('reviewers')],
+                'compiler': [compilers['name'] for compilers in item.get('compilers')],
+                'reviewers': [reviewers['name'] for reviewers in item.get('reviewers')],
                 'code': item.get('code'),
                 'edition': item.get('serializer_edition'),
                 'url': reverse(


### PR DESCRIPTION
   - handle by looping through compilers instead of assuming 1 compiler